### PR TITLE
fix: allow Threads view to show if MAT does not show it

### DIFF
--- a/analysis/heap-dump/impl/src/main/java/org/eclipse/jifa/hda/impl/VirtualThreadItem.java
+++ b/analysis/heap-dump/impl/src/main/java/org/eclipse/jifa/hda/impl/VirtualThreadItem.java
@@ -85,6 +85,7 @@ public class VirtualThreadItem extends Thread.Item {
 
     @Override
     public boolean isDaemon() {
-        return (Boolean) result.getColumnValue(row, COLUMN_DAEMON);
+        Object value = result.getColumnValue(row, COLUMN_DAEMON);
+        return value != null && Boolean.parseBoolean(value.toString());
     }
 }


### PR DESCRIPTION
In the event that MAT does not return detailed thread information, it might return blank strings in the columns. Force-casting this to Boolean results in an Exception. Instead of throwing an Exception, we attempt to parse this to a Boolean which returns 'false' instead. It allows the data to be presented as false, which is incorrect, but the API is specified as `boolean`, so this is probably the best answer.