### PR TITLE
Bump to Eclipse MAT 1.16.1

### DIFF
--- a/analysis/heap-dump/eclipse-mat-deps/eclipse-mat-deps.gradle
+++ b/analysis/heap-dump/eclipse-mat-deps/eclipse-mat-deps.gradle
@@ -15,7 +15,7 @@ import java.util.stream.Collectors
 
 plugins {
     id 'java'
-    id "dev.equo.p2deps" version "1.7.3"
+    id "dev.equo.p2deps" version "1.7.8"
 }
 
 apply from: "$rootDir/gradle/base.gradle"
@@ -68,8 +68,9 @@ p2deps {
             it.prop('osgi.arch', arch)
         })
 
-        p2repo 'https://download.eclipse.org/eclipse/updates/4.26/'
+        p2repo 'https://download.eclipse.org/eclipse/updates/4.34/'
         install 'com.ibm.icu'
+        install 'org.apache.aries.spifly.dynamic.bundle'
         install 'org.apache.felix.scr'
         install 'org.eclipse.core.commands'
         install 'org.eclipse.core.contenttype'
@@ -80,7 +81,10 @@ p2deps {
         install 'org.eclipse.equinox.event'
         install 'org.eclipse.equinox.preferences'
         install 'org.eclipse.equinox.registry'
+        install 'org.eclipse.equinox.supplement'
         install 'org.eclipse.osgi'
+        install 'org.eclipse.osgi.services'
+        install 'slf4j.simple'
 
         install 'org.eclipse.help'
         install 'org.eclipse.jface'
@@ -89,16 +93,23 @@ p2deps {
         install 'org.eclipse.ui'
         install 'org.eclipse.platform.feature.group'
 
-
-        p2repo 'https://download.eclipse.org/mat/1.14.0/update-site/'
+        p2repo 'https://download.eclipse.org/mat/1.16.1/update-site/'
         install 'org.eclipse.mat.api'
         install 'org.eclipse.mat.hprof'
         install 'org.eclipse.mat.parser'
         install 'org.eclipse.mat.report'
         install 'org.eclipse.mat.ui'
 
-        p2repo 'https://raw.githubusercontent.com/wiki/eclipse/jifa/resources/MatCalciteRepository-1.5.0/'
+        // Although Eclipse is at 4.34.0 we specify 4.32.0 here, because, Jakarta Annotation-api on
+        // 4.34.0 provides both 2.1.1 and 3.0.0, BUT, 3.0.0 is not compatible. And yet, there is no
+        // way that I found with the p2 plugin to specify download of a specific targeted version.
+        // By using 4.32.0 we get lucky enough that the compatible required deps are all in place.
+        p2repo 'https://download.eclipse.org/tools/orbit/simrel/orbit-aggregation/release/4.32.0/'
+        p2repo 'https://vlsi.github.io/mat-calcite-plugin-update-site/stable/'
         install 'MatCalcitePlugin'
+        install 'jakarta.annotation-api'
+        install 'bcutil'
+        install 'bcprov'
     }
 }
 
@@ -112,7 +123,7 @@ def depsDirPath =
             ext {
                 mat_deps_dir_name = depsDirName
                 mat_deps_dir_path = depsDirPath.toAbsolutePath().toString()
-                osgi_jar = 'org.eclipse.osgi-3.18.200.jar'
+                osgi_jar = 'org.eclipse.osgi-3.22.0.jar'
             }
         }
 }

--- a/analysis/heap-dump/hook/src/main/java/org/eclipse/mat/hprof/ui/HprofPreferences.java
+++ b/analysis/heap-dump/hook/src/main/java/org/eclipse/mat/hprof/ui/HprofPreferences.java
@@ -24,6 +24,12 @@ public class HprofPreferences {
 
     public static final String ADDITIONAL_CLASS_REFERENCES = "hprofAddClassRefs"; //$NON-NLS-1$
 
+    /** Whether to treat stack frames as pseudo-objects and methods as pseudo-classes */
+    public static final String P_METHODS = "methodsAsClasses"; //$NON-NLS-1$
+    public static final String NO_METHODS_AS_CLASSES = "none"; //$NON-NLS-1$
+    public static final String RUNNING_METHODS_AS_CLASSES = "running"; //$NON-NLS-1$
+    public static final String FRAMES_ONLY = "frames"; //$NON-NLS-1$
+
     public static ThreadLocal<HprofStrictness> TL = new ThreadLocal<>();
 
     public static void setStrictness(HprofStrictness strictness) {
@@ -70,4 +76,14 @@ public class HprofPreferences {
         }
     }
 
+    /**
+     * Preference for whether pseudo-objects should be created
+     * for stack frames and methods.
+     */
+    public static String methodsAsClasses()
+    {
+        String pref = Platform.getPreferencesService().getString(HprofPlugin.getDefault().getBundle().getSymbolicName(),
+                        HprofPreferences.P_METHODS, HprofPreferences.NO_METHODS_AS_CLASSES, null);
+        return pref;
+    }
 }


### PR DESCRIPTION
Bump to Eclipse MAT 1.16.1 and update required dependencies, including Calcite plugin.
- New and Noteworthy 1.15.0 notes [here](https://eclipse.dev/mat/1.15.0/noteworthy.html)
- New and Noteworthy 1.16.0 notes [here](https://eclipse.dev/mat/1.16.0/noteworthy.html)

Full commit here -- https://github.com/eclipse-mat/mat/compare/R_1.14.0...R_1.16.1.